### PR TITLE
Move apart worker and scheduler pods, so that images can be updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN rm miniconda.sh
 ENV PATH="/work/bin:/work/miniconda/bin:$PATH"
 
 # Install pydata stack
-RUN conda config --set always_yes yes --set changeps1 no
+RUN conda config --set always_yes yes --set changeps1 no --set auto_update_conda no
 RUN conda install notebook=4.2 ipywidgets psutil numpy scipy pandas bokeh scikit-learn statsmodels pip numba \
         scikit-image datashader holoviews nomkl matplotlib
 RUN conda install -c conda-forge fastparquet s3fs zict bcolz cytoolz dask distributed jupyter_dashboards

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ with all the necessary tools to run our cluster, in particular:
 
 This image will be used to run 3 types of services:
 
-- the `jupyter notebook` server, protected by password `acluster`. This password is defined
+- the `jupyter notebook` server, protected by password `jupyter`. This password is defined
 in conf/jupyter_notebook_config.py; to change it, you will need to rebuild this image
 and point the kubernetes definitions to the new version.
 - the `dask-scheduler` service,

--- a/config/jupyter_notebook_config.py
+++ b/config/jupyter_notebook_config.py
@@ -1,4 +1,4 @@
-c.NotebookApp.password = u'sha1:695c91d96e4a:6f64c2d285ab2eaa4abfa6385f801c6772a6dabd'
+c.NotebookApp.password = u'sha1:af82683fbade:60a8ce88ca12188b3f3d32639792e0dd9d9191c4'
 c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.token = ''
 c.NotebookApp.open_browser = False

--- a/kubernetes/dask_scheduler.yaml
+++ b/kubernetes/dask_scheduler.yaml
@@ -33,34 +33,3 @@ spec:
               cpu: 1
               memory: 1024Mi
           imagePullPolicy: IfNotPresent
----
-apiVersion: v1
-kind: ReplicationController
-metadata:
-  labels:
-    name: dask-worker
-    app: dask
-  name: dask-worker
-spec:
-  replicas: 10
-  selector:
-    name: dask-worker
-  template:
-    metadata:
-      labels:
-        name: dask-worker
-        app: dask
-    spec:
-      containers:
-        - name: dask-worker
-          image: mdurant/docker-distributed:renew
-          args: ["dask-worker", "dask-scheduler:8786", "--nthreads", "2",
-                 "--memory-limit", "6442450944"]
-          resources:
-            requests:
-              cpu: 1.8
-              memory: 6Gi
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            runAsUser: 1000
-          workingDir: /work

--- a/kubernetes/dask_scheduler.yaml
+++ b/kubernetes/dask_scheduler.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: dask-scheduler
-          image: mdurant/docker-distributed:renew
+          image: mdurant/dask-kubernetes:latest
           args: ["dask-scheduler"]
           ports:
           - name: rpc

--- a/kubernetes/dask_workers.yaml
+++ b/kubernetes/dask_workers.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    name: dask-worker
+    app: dask
+  name: dask-worker
+spec:
+  replicas: 10
+  selector:
+    name: dask-worker
+  template:
+    metadata:
+      labels:
+        name: dask-worker
+        app: dask
+    spec:
+      containers:
+        - name: dask-worker
+          image: mdurant/docker-distributed:renew
+          args: ["dask-worker", "dask-scheduler:8786", "--nthreads", "2",
+                 "--memory-limit", "6442450944"]
+          resources:
+            requests:
+              cpu: 1.8
+              memory: 6Gi
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 1000
+          workingDir: /work

--- a/kubernetes/dask_workers.yaml
+++ b/kubernetes/dask_workers.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: dask-worker
-          image: mdurant/docker-distributed:renew
+          image: mdurant/dask-kubernetes:latest
           args: ["dask-worker", "dask-scheduler:8786", "--nthreads", "2",
                  "--memory-limit", "6442450944"]
           resources:

--- a/kubernetes/jupyter-notebook.yaml
+++ b/kubernetes/jupyter-notebook.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: jupyter-notebook
-          image: mdurant/docker-distributed:latest
+          image: mdurant/dask-kubernetes:latest
           args: ["jupyter", "notebook", "--config=/work/config/jupyter_notebook_config.py", "/work"]
           ports:
             - name: http

--- a/kubernetes/jupyter-notebook.yaml
+++ b/kubernetes/jupyter-notebook.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: jupyter-notebook
-          image: mdurant/docker-distributed:renew
+          image: mdurant/docker-distributed:latest
           args: ["jupyter", "notebook", "--config=/work/config/jupyter_notebook_config.py", "/work"]
           ports:
             - name: http


### PR DESCRIPTION
Using the rolling-update, you can only have one resource-controler
in each file.

Also, set default password to "jupyter" (but new docker image remains to be rebuilt).