### PR TITLE
(WIP) Templating infrastructure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 .git
 README.md
 kubernetes
-docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 dist/
 .ipynb_checkpoints
 __pycache__
+.cache/

--- a/dask_kubernetes/cli/defaults.yaml
+++ b/dask_kubernetes/cli/defaults.yaml
@@ -1,0 +1,22 @@
+cluster:
+  num_nodes: 6
+  machine_type: n1-standard-4
+  disk_size: 50
+  zone: us-east1-b
+jupyter:
+  memory: 2048Mi
+  cpus: 1
+  port: 8888
+scheduler:
+  memory: 1024Mi
+  cpus: 1
+  image: mdurant/dask-kubernetes:latest
+  tcp_port: 8786
+  http_port: 9786
+  bokeh_port: 8787
+workers:
+  count: 8
+  cpus_per_worker: 1.8
+  memory_per_worker: 6800Mi
+  mem_factor: 0.95
+  image: mdurant/dask-kubernetes:latest

--- a/dask_kubernetes/cli/main.py
+++ b/dask_kubernetes/cli/main.py
@@ -22,8 +22,6 @@ from .utils import (call, check_output, required_commands, get_conf,
 logger = logging.getLogger(__name__)
 template_dir = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                         '../kubernetes'))
-defaults = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                        'defaults.yaml'))
 
 
 def start():

--- a/dask_kubernetes/cli/main.py
+++ b/dask_kubernetes/cli/main.py
@@ -20,8 +20,6 @@ from .utils import (call, check_output, required_commands, get_conf,
 
 
 logger = logging.getLogger(__name__)
-template_dir = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                        '../kubernetes'))
 
 
 def start():

--- a/dask_kubernetes/cli/utils.py
+++ b/dask_kubernetes/cli/utils.py
@@ -1,8 +1,14 @@
 import functools
+from math import ceil
+import os
 import subprocess
 import sys
+import yaml
 
 import click
+
+defaults = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                        'defaults.yaml'))
 
 
 def required_commands(*commands):

--- a/dask_kubernetes/cli/utils.py
+++ b/dask_kubernetes/cli/utils.py
@@ -143,7 +143,7 @@ def render_templates(conf, par):
         os.path.join(par, name): jenv.get_template(name).render(conf)
         for name in jenv.list_templates()
     }
-    configs[par + '.yaml'] = yaml.dump(conf)
+    configs[par + '.yaml'] = yaml.dump(conf, default_flow_style=False)
     return configs
 
 

--- a/dask_kubernetes/cli/utils.py
+++ b/dask_kubernetes/cli/utils.py
@@ -113,9 +113,7 @@ def get_conf(settings, args):
         settings = yaml.load(read_conf(settings))
         nested_update(conf, settings)
 
-    if args is None:
-        overrides = {}
-    else:
+    if args:
         overrides = [parse_cli_override(arg) for arg in args]
         for override in overrides:
             nested_update(conf, override)
@@ -145,6 +143,7 @@ def render_templates(conf, par):
         os.path.join(par, name): jenv.get_template(name).render(conf)
         for name in jenv.list_templates()
     }
+    configs[par + '.yaml'] = yaml.dump(conf)
     return configs
 
 

--- a/dask_kubernetes/cli/utils.py
+++ b/dask_kubernetes/cli/utils.py
@@ -1,5 +1,6 @@
 import functools
 from math import ceil
+import jinja2
 import os
 import subprocess
 import sys
@@ -9,6 +10,8 @@ import click
 
 defaults = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                         'defaults.yaml'))
+template_dir = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                        '../kubernetes'))
 
 
 def required_commands(*commands):

--- a/dask_kubernetes/cli/utils.py
+++ b/dask_kubernetes/cli/utils.py
@@ -35,3 +35,61 @@ def call(cmd):
 def check_output(cmd):
     click.secho("executing: {}".format(cmd), fg='green')
     return subprocess.check_output(cmd, shell=True).decode("utf-8")
+
+
+def mem_bytes(m):
+    """Translate java memory spec to bytes"""
+    mult = {'Ki': 2 ** 10, 'Mi': 2 ** 20, 'Gi': 2 ** 30}
+    for k, v in mult.items():
+        if k in m:
+            return v * int(m.replace(k, ''))
+    return m
+
+
+def get_conf(settings, args):
+    """Produce configuration dictionary
+
+    Starts with default settings, applies given YAML file, and overrides
+    with any further arguments, in that order.
+
+    Parameters
+    ----------
+    settings: str or None
+        YAML file with some or all of the entries in defaults.yaml
+    args: list of strings
+        Override parameters like "jupyter.port=443"."""
+    conf = yaml.load(open(defaults).read())
+    if settings is not None:
+        conf.update(yaml.load(open(settings).read()))
+    for arg in args:
+        key, value = arg.split('=')
+        conf0 = conf
+        for key_part in key.split('.')[:-1]:
+            conf0 = conf[key_part]
+        conf0[key.split('.')[-1]] = value
+    # worker memory should be slightly less than container capacity
+    factor = float(conf['workers']['mem_factor'])
+    conf['workers']['memory_per_worker2'] = int(factor * mem_bytes(
+        conf['workers']['memory_per_worker']))
+    conf['workers']['cpus_per_worker2'] = ceil(
+        conf['workers']['cpus_per_worker'])
+    return conf
+
+
+def render_templates(conf, par):
+    """Render given config into kubernetes yaml files, in par directory
+
+    Parameters
+    ----------
+    conf: dict
+        Configuration dictionary, from get_conf()
+    par: str
+        Directory to write to
+    """
+    jenv = jinja2.Environment()
+    for f in os.listdir(template_dir):
+        fn = os.path.join(template_dir, f)
+        templ = jenv.from_string(open(fn).read())
+        out = os.path.join(par, f)
+        with open(out, 'w') as f:
+            f.write(templ.render(conf))

--- a/dask_kubernetes/kubernetes/dask_external.yaml
+++ b/dask_kubernetes/kubernetes/dask_external.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-    - port: 8888
+    - port: {{jupyter.port}}
       targetPort: 8888
       name: jupyter-http
   selector:
@@ -24,13 +24,13 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-    - port: 8786
+    - port: {{scheduler.tcp_port}}
       targetPort: 8786
       name: dask-scheduler-tcp
-    - port: 9786
+    - port: {{scheduler.http_port}}
       targetPort: 9786
       name: dask-scheduler-http
-    - port: 8787
+    - port: {{scheduler.bokeh_port}}
       targetPort: 8787
       name: dask-scheduler-bokeh
   selector:

--- a/dask_kubernetes/kubernetes/dask_notebook.yaml
+++ b/dask_kubernetes/kubernetes/dask_notebook.yaml
@@ -24,8 +24,8 @@ spec:
               containerPort: 8888
           resources:
             requests:
-              cpu: 1
-              memory: 4Gi
+              cpu: {{jupyter.cpus}}
+              memory: {{jupyter.memory}}
           imagePullPolicy: Always
           securityContext:
             runAsUser: 1000

--- a/dask_kubernetes/kubernetes/dask_scheduler.yaml
+++ b/dask_kubernetes/kubernetes/dask_scheduler.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: dask-scheduler
-          image: mdurant/dask-kubernetes:latest
+          image: {{scheduler.image}}
           args: ["dask-scheduler"]
           ports:
           - name: rpc
@@ -30,6 +30,6 @@ spec:
             containerPort: 8787
           resources:
             requests: 
-              cpu: 1
-              memory: 1024Mi
+              cpu: {{scheduler.cpus}}
+              memory: {{scheduler.memory}}
           imagePullPolicy: Always

--- a/dask_kubernetes/kubernetes/dask_workers.yaml
+++ b/dask_kubernetes/kubernetes/dask_workers.yaml
@@ -6,7 +6,7 @@ metadata:
     app: dask
   name: dask-worker
 spec:
-  replicas: 8
+  replicas: {{workers.count}}
   selector:
     name: dask-worker
   template:
@@ -17,13 +17,15 @@ spec:
     spec:
       containers:
         - name: dask-worker
-          image: mdurant/dask-kubernetes:latest
-          args: ["dask-worker", "dask-scheduler:8786", "--nthreads", "2",
-                 "--memory-limit", "6442450944", "--interface",  "eth0"]
+          image: {{workers.image}}
+          args: ["dask-worker", "dask-scheduler:8786", "--nthreads",
+                 "{{workers.cpus_per_worker2}}", "--memory-limit",
+                 "{{workers.memory_per_worker2}}", "--interface",
+                 "eth0"]
           resources:
             requests:
-              cpu: 1.8
-              memory: 6800Mi
+              cpu: {{workers.cpus_per_worker}}
+              memory: {{workers.memory_per_worker}}
           imagePullPolicy: Always
           securityContext:
             runAsUser: 1000

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,51 @@
+import io
+from textwrap import dedent
+import os
+from dask_kubernetes.cli.utils import get_conf, render_templates
+
+import pytest
+
+
+PKG = os.path.dirname(os.path.dirname(__file__))
+
+
+@pytest.fixture
+def config():
+    return io.BytesIO(dedent(b"""\
+    cluster:
+      num_nodes: 12
+    """))
+
+
+def test_get_conf_default():
+    result = get_conf(None, None)
+    assert set(result.keys()) == {'cluster', 'jupyter', 'scheduler', 'workers'}
+
+
+def test_file_overrides(config):
+    result = get_conf(config, None)
+    assert result['cluster']['num_nodes'] == 12
+    assert result['cluster']['zone'] == 'us-east1-b'
+
+
+def test_cli():
+    result = get_conf(None, ['cluster.num_nodes=12'])
+    assert result['cluster']['num_nodes'] == '12'  # TODO: types
+    assert result['cluster']['zone'] == 'us-east1-b'
+
+
+def test_cli_overrides(config):
+    result = get_conf(None, ['cluster.num_nodes=15'])
+    assert result['cluster']['num_nodes'] == '15'
+    assert result['cluster']['zone'] == 'us-east1-b'
+
+
+def test_render_templates():
+    config = {
+        "jupyter": {"port": 443},
+        "scheduler": {},
+        "workers": {},
+    }
+    result = render_templates(config, '')
+    # probably want to do some more verification here.
+    assert len(result)


### PR DESCRIPTION
Instead of editing kubernetes files directly, put all config in a YAML file and edit that, or give override values on the command line. Allows, for instance, setting the notebook port like:

    dask-kubernetes create dask defaults.yaml jupyter.port=443

(specifying a yaml should be optional, but isn't yet)

[ ] requires tests
[ ] requires error checking of parameters
[ ] requires documentation
[ ] may need refining of the CLI