### PR TITLE
Make sure CPUs is interpreted as a number

### DIFF
--- a/dask_kubernetes/cli/utils.py
+++ b/dask_kubernetes/cli/utils.py
@@ -125,7 +125,7 @@ def get_conf(settings, args):
     conf['workers']['memory_per_worker2'] = int(factor * mem_bytes(
         conf['workers']['memory_per_worker']))
     conf['workers']['cpus_per_worker2'] = ceil(
-        conf['workers']['cpus_per_worker'])
+        float(conf['workers']['cpus_per_worker']))
     return conf
 
 


### PR DESCRIPTION
If worker cpus are passed from the command line, the value is interpreted as a string, and `ceil()` complains. Wrapping the value in `float()` solves the problem.